### PR TITLE
Various improvements / proposition

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -x
+
+dotnet tool restore
+dotnet run --project build/Build.fsproj -- $@

--- a/build/Helpers.fs
+++ b/build/Helpers.fs
@@ -85,9 +85,9 @@ let npm =
 
     createProcess npmPath
 
-let py =
+let python =
     let path =
-        match ProcessUtils.tryFindFileOnPath "py" with
+        match ProcessUtils.tryFindFileOnPath "python" with
         | Some path -> path
         | None ->
             "py was not found in path. Please install it and make sure it's available from your path."

--- a/build/TestTasks.fs
+++ b/build/TestTasks.fs
@@ -17,7 +17,7 @@ let runTestsDotNet = BuildTask.create "RunTestsDotnet" [clean; build;] {
 let runTestsPy = BuildTask.create "RunTestsPy" [clean; build;] {
     for test in ProjectInfo.testProjects do
         run dotnet $"fable {test} --lang py -o {test}/py" ""
-        run py $"{test}/py/main.py" ""
+        run python $"{test}/py/main.py" ""
 }
 
 let runTestsJs = BuildTask.create "RunTestsJs" [clean; build;] {

--- a/src/Fable.Pyxpecto.fsproj
+++ b/src/Fable.Pyxpecto.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/Fable.Pyxpecto.fsproj
+++ b/src/Fable.Pyxpecto.fsproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="4.0.0" />
     <PackageReference Include="Fable.Python" Version="4.1.3" />
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/src/Fable.Pyxpecto.fsproj
+++ b/src/Fable.Pyxpecto.fsproj
@@ -20,9 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="4.0.0" />
-    <PackageReference Include="Fable.Python" Version="4.1.3" />
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
+    <PackageReference Include="Fable.Core" Version="4.1.0" />
+    <PackageReference Include="Fable.Python" Version="4.3.0" />
+    <PackageReference Update="FSharp.Core" Version="5.0.0" />
   </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Hello @Freymaurer ,

I am currently working on the Python version of Thoth.Json and want to you your library as it allows to the same API for running tests against .NET, JavaScript and Python.

While doing so, I discovered that the library target `net6.0` which means that user also have to use that target. In general, we make library target `netstandard2.0` as it allows to consume the library across a lot of different target framework.

I also took this opportunity to lower the version of `FSharp.Core` required, otherwise users will have warnings about a downgrade in their code:

![CleanShot 2023-11-19 at 16 51 05](https://github.com/Freymaurer/Fable.Pyxpecto/assets/4760796/8c9b2ce6-4222-4061-86b3-3cb584198af4)

While testing locally, I saw that the build system was using expecting python to be at `py` however this is not standard. So I took this opportunity to use the standard `python` executable.